### PR TITLE
[fix] Fix type error in call to PlatformAPI.get_repo

### DIFF
--- a/repobee_feedback/feedback.py
+++ b/repobee_feedback/feedback.py
@@ -11,7 +11,7 @@ import pathlib
 import re
 import sys
 import argparse
-from typing import Iterable, Tuple, List
+from typing import Iterable, Tuple, List, Mapping
 
 import repobee_plug as plug
 
@@ -21,7 +21,7 @@ BEGIN_ISSUE_PATTERN = r"#ISSUE#(.*?)#(.*)"
 
 
 def callback(args: argparse.Namespace, api: plug.PlatformAPI) -> None:
-    repo_name_to_team = {
+    repo_name_to_team: Mapping[str, plug.StudentTeam] = {
         plug.generate_repo_name(
             student_team.name, assignment_name
         ): student_team
@@ -45,7 +45,7 @@ def callback(args: argparse.Namespace, api: plug.PlatformAPI) -> None:
             issue, repo_name, args.truncation_length
         )
         if open_issue:
-            repo = api.get_repo(repo_name, repo_name_to_team[repo_name])
+            repo = api.get_repo(repo_name, repo_name_to_team[repo_name].name)
             api.create_issue(issue.title, issue.body, repo)
         else:
             plug.echo("Skipping {}".format(repo_name))


### PR DESCRIPTION
Fix #14 

This PR fixes a type error where `PlatformAPI.get_repo(str,str)` was called with a `StudentRepo` instead of a `str`. This caused a crash with the GitLabAPI.

Note that I had to specify the type of the mapping, as it can't be inferred (there's just a bunch of `Any`, which is of no help).