### PR TITLE
[misc] Add types-dataclasses to fix static analysis error

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,4 +5,4 @@ codecov
 black
 flake8
 mypy
-types-dataclasses
+types-dataclasses;python_version<'3.7',

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,3 +5,4 @@ codecov
 black
 flake8
 mypy
+types-dataclasses

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ test_requirements = [
     "black",
     "flake8",
     "mypy",
+    "types-dataclasses",
 ]
 required = ["repobee>=3.0.0-beta.1"]
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ test_requirements = [
     "black",
     "flake8",
     "mypy",
-    "types-dataclasses",
+    "types-dataclasses;python_version<'3.7'",
 ]
 required = ["repobee>=3.0.0-beta.1"]
 


### PR DESCRIPTION
Fixes a static analysis error by installing required types-dataclasses for Python<3.7. In Python 3.7+, the typings are in the standard library stubs.