### PR TITLE
[misc] Don't fail CI if Codecov upload fails

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,5 +51,5 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           file: ./coverage.xml


### PR DESCRIPTION
CI is failing because too many coverage reports have been uploaded for the same commit. This PR ignores Codecov upload failures. We'll know that an upload failed anyway as the status won't be posted.