### PR TITLE
[feat] Indent issue body when working with multi-issue file

### DIFF
--- a/repobee_feedback/feedback.py
+++ b/repobee_feedback/feedback.py
@@ -11,6 +11,7 @@ import pathlib
 import re
 import sys
 import argparse
+from textwrap import indent
 from typing import Iterable, Tuple, List, Mapping
 
 import repobee_plug as plug
@@ -18,7 +19,7 @@ import repobee_plug as plug
 PLUGIN_NAME = "feedback"
 
 BEGIN_ISSUE_PATTERN = r"#ISSUE#(.*?)#(.*)"
-
+INDENTATION_STR = "    >"
 
 def callback(args: argparse.Namespace, api: plug.PlatformAPI) -> None:
     repo_name_to_team: Mapping[str, plug.StudentTeam] = {
@@ -110,11 +111,10 @@ class Feedback(plug.Plugin, plug.cli.Command):
 
 def _ask_for_open(issue: plug.Issue, repo_name: str, trunc_len: int) -> bool:
     plug.echo(
-        'Processing issue "{}" for {}: {}{}'.format(
+        '\nProcessing issue "{}" for {}:\n{}'.format(
             issue.title,
             repo_name,
-            issue.body[:trunc_len],
-            "[...]" if len(issue.body) > trunc_len else "",
+            indent(issue.body[:trunc_len], INDENTATION_STR)
         )
     )
     return (

--- a/repobee_feedback/feedback.py
+++ b/repobee_feedback/feedback.py
@@ -21,6 +21,7 @@ PLUGIN_NAME = "feedback"
 BEGIN_ISSUE_PATTERN = r"#ISSUE#(.*?)#(.*)"
 INDENTATION_STR = "    >"
 
+
 def callback(args: argparse.Namespace, api: plug.PlatformAPI) -> None:
     repo_name_to_team: Mapping[str, plug.StudentTeam] = {
         plug.generate_repo_name(
@@ -114,7 +115,7 @@ def _ask_for_open(issue: plug.Issue, repo_name: str, trunc_len: int) -> bool:
         '\nProcessing issue "{}" for {}:\n{}'.format(
             issue.title,
             repo_name,
-            indent(issue.body[:trunc_len], INDENTATION_STR)
+            indent(issue.body[:trunc_len], INDENTATION_STR),
         )
     )
     return (

--- a/repobee_feedback/feedback.py
+++ b/repobee_feedback/feedback.py
@@ -19,7 +19,8 @@ import repobee_plug as plug
 PLUGIN_NAME = "feedback"
 
 BEGIN_ISSUE_PATTERN = r"#ISSUE#(.*?)#(.*)"
-INDENTATION_STR = "    >"
+INDENTATION_STR = "    "
+TRUNC_SIGN = "[...]"
 
 
 def callback(args: argparse.Namespace, api: plug.PlatformAPI) -> None:
@@ -110,19 +111,20 @@ class Feedback(plug.Plugin, plug.cli.Command):
         callback(self.args, api)
 
 
+def _indent_issue_body(body: str, trunc_len: int):
+    indented_body = indent(body[:trunc_len], INDENTATION_STR)
+    body_end = TRUNC_SIGN if len(body) > trunc_len else ""
+    return indented_body + body_end
+
+
 def _ask_for_open(issue: plug.Issue, repo_name: str, trunc_len: int) -> bool:
-    plug.echo(
-        '\nProcessing issue "{}" for {}:\n{}'.format(
-            issue.title,
-            repo_name,
-            indent(issue.body[:trunc_len], INDENTATION_STR),
-        )
+    indented_body = _indent_issue_body(issue.body, trunc_len)
+    issue_description = (
+        f'\nProcessing issue "{issue.title}" for {repo_name}:\n{indented_body}'
     )
+    plug.echo(issue_description)
     return (
-        input(
-            'Open issue "{}" in repo {}? (y/n) '.format(issue.title, repo_name)
-        )
-        == "y"
+        input(f'Open issue "{issue.title}" in repo {repo_name}? (y/n) ') == "y"
     )
 
 

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -232,14 +232,17 @@ class TestIndentIssueBody:
         self,
     ):
         """Test that a long issue body get truncated to a certain length"""
-        body = "Hello\nworld\n"
-        indented_body = feedback._indent_issue_body(body, 10)
-        assert feedback.TRUNC_SIGN in indented_body
+        body = "Hello world\nfrom python\n"
+        indented_body = feedback._indent_issue_body(
+            body, trunc_len=len(body) // 2
+        )
+        assert indented_body.startswith(f"{feedback.INDENTATION_STR}Hello")
+        assert indented_body.endswith(feedback.TRUNC_SIGN)
 
     def test_issue_indented_and_not_truncated(
         self,
     ):
         """Test that a short issue body does not get truncated"""
         body = "This is an issue\n"
-        indented_body = feedback._indent_issue_body(body, 20)
-        assert not feedback.TRUNC_SIGN in indented_body
+        indented_body = feedback._indent_issue_body(body, 2 * len(body))
+        assert indented_body == f"{feedback.INDENTATION_STR}{body}"

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -223,3 +223,23 @@ class TestCallback:
         feedback.callback(args=args, api=api_mock)
 
         api_mock.create_issue.assert_has_calls(expected_calls, any_order=True)
+
+
+class TestIndentIssueBody:
+    """Tests for the method that addds indentation to the issue body"""
+
+    def test_issue_indented_and_truncated(
+        self,
+    ):
+        """Test that a long issue body get truncated to a certain length"""
+        body = "Hello\nworld\n"
+        indented_body = feedback._indent_issue_body(body, 10)
+        assert feedback.TRUNC_SIGN in indented_body
+
+    def test_issue_indented_and_not_truncated(
+        self,
+    ):
+        """Test that a short issue body does not get truncated"""
+        body = "This is an issue\n"
+        indented_body = feedback._indent_issue_body(body, 20)
+        assert not feedback.TRUNC_SIGN in indented_body


### PR DESCRIPTION
Fix #13

I opted to not implement terminal cleaning for each issue because of the scrolling up little problem. If you wish to have this feature (cleaning the terminal for each issue read), I can implement it, no problem :)

Please comment on anything that does not look good for you, I'm always totally open to suggestions and changes :D